### PR TITLE
Removed double line break after cue number

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,9 +69,9 @@ module.exports = function () {
       
          if (/^[0-9]+:/m.test(vttLine)) {
             if (count === 0) {
-              vttLine = ++count + '\r\n' + vttLine;
+              vttLine = ++count + '\r' + vttLine;
             } else {
-              vttLine = '\r\n' + ++count + '\r\n' + vttLine;
+              vttLine = '\r\n' + ++count + '\r' + vttLine;
             }
           }
 


### PR DESCRIPTION
I use this module in my app - I have found that it generates a slightly malformed SRT file. 

According to the SRT spec a cue should look like this:
4
00:00:09,980  -->  00:00:11,599
disagree about what even counts as
the oldest written word scholars

I have found this module generates an SRT cue that looks like this:
4

00:00:09,980  -->  00:00:11,599
disagree about what even counts as
the oldest written word scholars

Because of this double line break.